### PR TITLE
Explicitly preclude earlier than TLS 1.2

### DIFF
--- a/input/tls.xml
+++ b/input/tls.xml
@@ -327,7 +327,7 @@
                 <selectable id="tlsc_downgrade_protection">supplemental downgrade protection</selectable>
                 <selectable id="tlsc_resumption">session resumption</selectable>
                 <selectable>no optional functionality</selectable></selectables>
-              and shall abort attempts by a server to negotiate all other TLS or SSL versions. 
+              and shall abort attempts by a server to negotiate any TLS or SSL version prior to TLS 1.2 (RFC 5246). 
             </title>
             <note role="application">
               <h:p>


### PR DESCRIPTION
The current text would preclude supporting any updates to 1.2, 1.3 or future releases without an update to the Package. This explicitly precludes the use of anything older than 1.2 but would still allow support for future versions without causing problems that may require special operating modes to block certain functions (and potentially break a lot of access).